### PR TITLE
Fixed ActiveResource 3.1 incompatibility

### DIFF
--- a/lib/sk_sdk/base.rb
+++ b/lib/sk_sdk/base.rb
@@ -15,9 +15,9 @@ class SK::SDK::Base < ActiveResource::Base
   self.format = :json
   # hook before init in activeresource base because json comes in nested:
   # {client={data}
-  def initialize(attributes = {})
+  def initialize(attributes = {}, *args)
     attr = attributes[self.class.element_name] || attributes
-    super(attr)
+    super(attr, *args)
   end
 
   def save; save_with_validation; end

--- a/spec/sk_sdk/base_spec.rb
+++ b/spec/sk_sdk/base_spec.rb
@@ -35,4 +35,10 @@ describe SK::SDK::Base, "make new class" do
     p.new_record?.should be_true
   end
 
+  it "should allow multiple parameters in initializer" do
+    expect {
+      Client.new({ :first_name => 'herbert' }, true)
+    }.should_not raise_error(ArgumentError)
+  end
+
 end


### PR DESCRIPTION
ActiveResource 3.1 changed a signature of ActiveResoruce::Base#initialize method from

``` ruby
def initialize(attributes = {})
```

to 

``` ruby
def initialize(attributes = {}, persisted = false)
```

Therefore SK_SDK which overrides this method is no longer compatible.

```
.rvm/gems/ruby-1.9.2-p290/gems/sk_sdk-0.0.8/lib/sk_sdk/base.rb:18:in `initialize': wrong number of arguments (2 for 1) (ArgumentError)
    from .rvm/gems/ruby-1.9.2-p290/gems/activeresource-3.1.0/lib/active_resource/base.rb:926:in `new'
    from .rvm/gems/ruby-1.9.2-p290/gems/activeresource-3.1.0/lib/active_resource/base.rb:926:in `instantiate_record
```

This pull request contains a patch which fixes the incompatibility and gives some love to ActiveResource 3.1.
